### PR TITLE
Fix Vue.js - Point to Specific Version

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
     <!-- ComfyJS -->
     <script src="js/comfy.js"></script>
     <!-- VueJS - Production -->
-    <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+    <script src="https://unpkg.com/vue@2"></script>
   </head>
   <body>
     <!-- Header -->


### PR DESCRIPTION
Close #3 

Should of been pointing to a specific version from the beginning. Update to point to V2.